### PR TITLE
Don't switch to newly created projects

### DIFF
--- a/library/openshift_project.py
+++ b/library/openshift_project.py
@@ -22,7 +22,7 @@ def main():
       module.exit_json(changed=False)
 
     if state == 'present':
-      cmd = 'oc new-project'
+      cmd = 'oc new-project --skip-config-write'
     else:
       cmd = 'oc delete-project'
 


### PR DESCRIPTION
Using the module has the unwanted sideeffect of changing the current
context on the system `oc` runs on. This is potentionally dangerous as
an user working on the system may not notice said change.