### PR TITLE
Change the process_template parameter switch from -v to -p

### DIFF
--- a/library/openshift_resource.py
+++ b/library/openshift_resource.py
@@ -241,7 +241,7 @@ class ResourceModule:
     self.debug("process_template")
 
     if arguments:
-      args = [_ for arg in arguments.items() for _ in ('-v', "=".join(arg)) if not arg[1].startswith('__omit_place_holder__')]
+      args = [_ for arg in arguments.items() for _ in ('-p', "=".join(arg)) if not arg[1].startswith('__omit_place_holder__')]
     else:
       args = []
 


### PR DESCRIPTION
Since OpenShift 3.5 the oc process command switch -p is used
instead of -v. In OpenShift 3.10 the switch -v support has been
removed completly.